### PR TITLE
Add setup.cfg and venv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Heavily under development. Assume everything will be moved and broken at some
 point or other in the next couple of months.
 
 
+## Setting up Johnny in a virtual environment
+From the Johnny source directory:
+
+1. `python -m venv venv`
+2. `source venv/bin/activate`
+3. `pip install -e .`
+4. `export JOHNNY_ROOT=/path/to/johnny/data && ./bin/johnny-web`
+4. Visit the web UI at http://localhost:5000
+
+## Graphviz
+Extra steps are required to install Graphviz: https://pygraphviz.github.io/documentation/stable/install.html
+
 ## Inputs
 
 There a two tools, which feed off of CSV downloads from either of thinkorswim or
@@ -25,7 +37,9 @@ You will need both a positions file and a transactions log downloads.
 ### Tastyworks
 
 - **Positions** Go to the `Positions` tab, click on `CSV`, save file to a
-  directory.
+  directory. Make sure you have the following columns in your position tab: 
+  `price, mark, cost, net_liq, delta per quantity`.
+  
 
 - **Transactions** Go to the `History` tab, click on `CSV`, select a date range
   up to a point where you had no positions, scroll all the way to the bottom (to

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ point or other in the next couple of months.
 ## Setting up Johnny in a virtual environment
 From the Johnny source directory:
 
-1. `python -m venv venv`
-2. `source venv/bin/activate`
-3. `pip install -e .`
-4. `export JOHNNY_ROOT=/path/to/johnny/data && ./bin/johnny-web`
+1. Setup the virtual environment: `python3 -m venv venv`
+2. Activate it: `source venv/bin/activate`
+3. Install the package for local development into the virtual environment: `pip install -e .`
+4. Run the web UI: `export JOHNNY_ROOT=/path/to/johnny/data && ./bin/johnny-web`
 4. Visit the web UI at http://localhost:5000
 
 ## Graphviz

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ From the Johnny source directory:
 
 1. Setup the virtual environment: `python3 -m venv venv`
 2. Activate it: `source venv/bin/activate`
-3. Install the package for local development into the virtual environment: `pip install -e .`
+3. Install the package for local development into the virtual environment: `pip install --editable .`
 4. Run the web UI: `export JOHNNY_ROOT=/path/to/johnny/data && ./bin/johnny-web`
 4. Visit the web UI at http://localhost:5000
 
-## Graphviz
+## Graphviz (optional)
 Extra steps are required to install Graphviz: https://pygraphviz.github.io/documentation/stable/install.html
 
 ## Inputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,26 @@ package_dir =
     johnny = johnny/base
 packages = find:
 python_requires = >=3.6
+install_requires =
+    click~=8.0.1
+    Flask~=2.0.1
+    cycler~=0.10.0
+    decorator~=4.4.2
+    itsdangerous~=2.0.1
+    Jinja2~=3.0.1
+    kiwisolver~=1.3.1
+    MarkupSafe~=2.0.1
+    matplotlib~=3.4.2
+    more-itertools~=8.8.0
+    networkx~=2.5.1
+    numpy~=1.20.3
+    petl~=1.7.4
+    Pillow~=8.2.0
+    protobuf~=3.17.3
+    pyparsing~=2.4.7
+    python-dateutil~=2.8.1
+    six~=1.16.0
+    Werkzeug~=2.0.1
 
 [options.packages.find]
 where = johnny/base

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,23 @@
+[metadata]
+name = Johnny
+version = 0.0.1
+author = Martin Blais
+description = blais@furius.ca
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/beancount/johnny
+project_urls =
+    Bug Tracker = https://github.com/beancount/johnny/issues
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: GPL-2.0
+    Operating System :: OS Independent
+
+[options]
+package_dir =
+    johnny = johnny/base
+packages = find:
+python_requires = >=3.6
+
+[options.packages.find]
+where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,4 @@ packages = find:
 python_requires = >=3.6
 
 [options.packages.find]
-where = src
+where = johnny/base


### PR DESCRIPTION
This one is a little more complicated.

A lot has changed since I last bundled a python package ~2 years ago, and it looks like setup.cfg is recommended over setup.py.

I think this will be the easiest way for someone new to the project to get up and running.

I pulled the latest dependencies and everything seems to be working great, let me know if there are different versions you want pinned.

It would be great if someone can give this a test-run before merging.

```
~/I/johnny ❯❯❯ python3 -m venv venv
~/I/johnny ❯❯❯ source venv/bin/activate
(venv) ~/I/johnny ❯❯❯ pip install --editable .
Obtaining file:///Users/sean/IdeaProjects/johnny
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting click~=8.0.1
  Using cached click-8.0.1-py3-none-any.whl (97 kB)
Collecting numpy~=1.20.3
  Using cached numpy-1.20.3-cp39-cp39-macosx_11_0_arm64.whl
Collecting protobuf~=3.17.3
  Using cached protobuf-3.17.3-py2.py3-none-any.whl (173 kB)
Collecting itsdangerous~=2.0.1
  Using cached itsdangerous-2.0.1-py3-none-any.whl (18 kB)
Collecting MarkupSafe~=2.0.1
  Using cached MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl (18 kB)
Collecting kiwisolver~=1.3.1
  Using cached kiwisolver-1.3.1-cp39-cp39-macosx_11_0_arm64.whl
Collecting Flask~=2.0.1
  Using cached Flask-2.0.1-py3-none-any.whl (94 kB)
Collecting python-dateutil~=2.8.1
  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
Collecting Werkzeug~=2.0.1
  Using cached Werkzeug-2.0.1-py3-none-any.whl (288 kB)
Collecting Pillow~=8.2.0
  Using cached Pillow-8.2.0-cp39-cp39-macosx_11_0_arm64.whl (2.7 MB)
Collecting networkx~=2.5.1
  Using cached networkx-2.5.1-py3-none-any.whl (1.6 MB)
Collecting pyparsing~=2.4.7
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Collecting petl~=1.7.4
  Using cached petl-1.7.4-py3-none-any.whl
Collecting Jinja2~=3.0.1
  Using cached Jinja2-3.0.1-py3-none-any.whl (133 kB)
Collecting decorator~=4.4.2
  Using cached decorator-4.4.2-py2.py3-none-any.whl (9.2 kB)
Collecting six~=1.16.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting matplotlib~=3.4.2
  Using cached matplotlib-3.4.2-cp39-cp39-macosx_11_0_arm64.whl
Collecting cycler~=0.10.0
  Using cached cycler-0.10.0-py2.py3-none-any.whl (6.5 kB)
Collecting more-itertools~=8.8.0
  Using cached more_itertools-8.8.0-py3-none-any.whl (48 kB)
Installing collected packages: six, MarkupSafe, Werkzeug, python-dateutil, pyparsing, Pillow, numpy, kiwisolver, Jinja2, itsdangerous, decorator, cycler, click, protobuf, petl, networkx, more-itertools, m
atplotlib, Flask, Johnny
  Running setup.py develop for Johnny
Successfully installed Flask-2.0.1 Jinja2-3.0.1 Johnny-0.0.1 MarkupSafe-2.0.1 Pillow-8.2.0 Werkzeug-2.0.1 click-8.0.1 cycler-0.10.0 decorator-4.4.2 itsdangerous-2.0.1 kiwisolver-1.3.1 matplotlib-3.4.2 mor
e-itertools-8.8.0 networkx-2.5.1 numpy-1.20.3 petl-1.7.4 protobuf-3.17.3 pyparsing-2.4.7 python-dateutil-2.8.1 six-1.16.0
(venv) ~/I/johnny ❮❮❮ export JOHNNY_ROOT=/Users/sean/Johnny-data && ./bin/johnny-web
 * Serving Flask app 'johnny.webapp.app' (lazy loading)
 * Environment: development
 * Debug mode: on
[2021-06-17 13:08:17,170] INFO in app: Initializing application state from '/Users/sean/Johnny-data'...
[2021-06-17 13:08:17,426] INFO in app: Done.
INFO:buff:Done.
INFO:werkzeug: * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
INFO:werkzeug: * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 457-273-866
[2021-06-17 13:08:17,758] INFO in app: Initializing application state from '/Users/sean/Johnny-data'...
[2021-06-17 13:08:17,997] INFO in app: Done.
INFO:buff:Done.
```