### PR TITLE
Cleanup typos found while reading code and markdown

### DIFF
--- a/johnny/base/discovery.py
+++ b/johnny/base/discovery.py
@@ -33,7 +33,7 @@ MatchFn = Callable[[str], Optional[Tuple[str, str, callable]]]
 
 def FindFiles(fileordirs: List[str],
               matchers: List[MatchFn]) -> Dict[str, callable]:
-    """Read in the transations log files from given directory and filenames."""
+    """Read in the transactions log files from given directory and filenames."""
 
     # If input is empty, use the CWD.
     if not fileordirs:

--- a/johnny/base/instrument.md
+++ b/johnny/base/instrument.md
@@ -48,7 +48,7 @@ needed on its own.
   This is a multiplier for the quantity. For equities, this is 1. For equity
   options, it should be set to 100. For futures contracts, set to whatever the
   multiplier for the contract is. (These values are static and technically are
-  inferred automatically from the underlying and instrumen ttype.
+  inferred automatically from the underlying and instrument type.)
 
 The currency that the instrument is quoted in is not included; we assume the US
 dollar is the quoting currency so far.

--- a/johnny/base/positions.md
+++ b/johnny/base/positions.md
@@ -6,7 +6,7 @@ Here is the definition of the fields we're expecting from the positions file;
   the brokerage. This can be used if a file contains information about multiple
   accounts.
 
-- `group: Optionnal[str]`: A group name that can be created by the application, if
+- `group: Optional[str]`: A group name that can be created by the application, if
   possible. thinkorswim has the ability to create position groups. Tastyworks
   does not. This is a kind of user label common to multiple positions.
 
@@ -17,7 +17,7 @@ Here is the definition of the fields we're expecting from the positions file;
   The individual fields of the instrument's symbol may be expanded into their
   individual components. See the file "instrument.md" for details.
 
-- `quantity: Decimal`: The quantity helpd. This number is signed, positive if
+- `quantity: Decimal`: The quantity held. This number is signed, positive if
   long, negative if short. Note that this is different than the `transactions`
   table.
 
@@ -34,7 +34,7 @@ Here is the definition of the fields we're expecting from the positions file;
 - `cost: Decimal`: The total cost for acquiring this position. This is a signed
   value as well, following the `price` field.
 
-- `net_liq: Decimal`: The total value of this position, as mark by the `mark`
+- `net_liq: Decimal`: The total value of this position, as marked by the `mark`
   field. This is a signed value as well, following the `mark` field.
 
 Note that pairs of `price` and `cost`, `mark` and `net_liq` are redundant. We

--- a/johnny/base/transactions.md
+++ b/johnny/base/transactions.md
@@ -3,7 +3,7 @@
 ## Opening and Closing
 
 The transactions log is not assumed to include opening transactions, nor closing
-(mark-to-market) transactions. These are synthesizes in coordinations with a
+(mark-to-market) transactions. These are synthesized in coordination with a
 positions table.
 
 
@@ -119,7 +119,7 @@ A normalized transactions table contains the following columns and data types.
   sides.)
 
 - `chain_id`: A unique random id which links together transactions grouped
-  together in a sequence of events. A "trade", or "chain" ofrelated transactions
+  together in a sequence of events. A "trade", or "chain" of related transactions
   over time. For instance, selling a strangle, then closing one side, and
   rolling the other side, and then closing, could be considered a single chain
   of events.


### PR DESCRIPTION
cleaning up typos I found while reading the code and markdown files