### PR TITLE
TOSWeb parsing

### DIFF
--- a/johnny/sources/thinkorswim_csv/transactions.py
+++ b/johnny/sources/thinkorswim_csv/transactions.py
@@ -773,6 +773,7 @@ def _ParseTradeDescription(description: str) -> Dict[str, Any]:
 
     regexp = "".join(
         [
+            "(?P<web>TOSWeb )?",
             "(?P<type>MSO )?",
             "(?P<side>BOT|SOLD) ",
             "(?P<quantity>[+-]?[0-9.,]+) ",


### PR DESCRIPTION
When transacting (buying/selling) on Think or Swim Web platform (https://trade.thinkorswim.com/) the resultant statements generated by ToS prepends the trade description with TOSWeb which causes parsing errors.  This results in:
Error messages like:  AssertionError: TOSWeb BOT +100 XXX @39.375

